### PR TITLE
Options to hide `serverURL` and `rememberLogin`

### DIFF
--- a/RealmLoginKit Apple/RealmLoginKit.xcodeproj/project.pbxproj
+++ b/RealmLoginKit Apple/RealmLoginKit.xcodeproj/project.pbxproj
@@ -65,8 +65,8 @@
 		2290FFCD1E3072AA0039DACF /* LoginViewControllerTransitioning.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginViewControllerTransitioning.swift; sourceTree = "<group>"; };
 		22AEE18A1E2F3F1F00CBB40A /* LoginTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginTableViewCell.swift; sourceTree = "<group>"; };
 		22EC43581E3246FF009BBA75 /* RealmLoginKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RealmLoginKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		22EC435A1E3246FF009BBA75 /* RealmLoginKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RealmLoginKit.h; path = RealmLoginKit/RealmLoginKit.h; sourceTree = "<group>"; };
-		22EC435B1E3246FF009BBA75 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = RealmLoginKit/Info.plist; sourceTree = "<group>"; };
+		22EC435A1E3246FF009BBA75 /* RealmLoginKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RealmLoginKit.h; sourceTree = "<group>"; };
+		22EC435B1E3246FF009BBA75 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2B9E1102BE07E9713B0DF556 /* Pods-RealmLoginKitExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealmLoginKitExample.release.xcconfig"; path = "Pods/Target Support Files/Pods-RealmLoginKitExample/Pods-RealmLoginKitExample.release.xcconfig"; sourceTree = "<group>"; };
 		31E6129F9B4030E07885A423 /* Pods_RealmLoginKitUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RealmLoginKitUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		33FD4046462D1AE75EE84FBB /* Pods_RealmLoginKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RealmLoginKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -126,8 +126,6 @@
 			isa = PBXGroup;
 			children = (
 				221840F51E2CCBB900E85B6E /* RealmLoginKit */,
-				22EC435A1E3246FF009BBA75 /* RealmLoginKit.h */,
-				22EC435B1E3246FF009BBA75 /* Info.plist */,
 				221840A91E2CC79000E85B6E /* RealmLoginKitExample */,
 				221840BE1E2CC79100E85B6E /* RealmLoginKitTests */,
 				221840C91E2CC79100E85B6E /* RealmLoginKitUITests */,
@@ -219,6 +217,8 @@
 		221840F51E2CCBB900E85B6E /* RealmLoginKit */ = {
 			isa = PBXGroup;
 			children = (
+				22EC435A1E3246FF009BBA75 /* RealmLoginKit.h */,
+				22EC435B1E3246FF009BBA75 /* Info.plist */,
 				225574BB1E2DFC0500C52098 /* Extensions */,
 				221840F61E2CCBB900E85B6E /* Controllers */,
 				221840F71E2CCBB900E85B6E /* Models */,

--- a/RealmLoginKit Apple/RealmLoginKit/Views/LoginTableViewCell.swift
+++ b/RealmLoginKit Apple/RealmLoginKit/Views/LoginTableViewCell.swift
@@ -19,39 +19,36 @@
 import UIKit
 import TORoundedTableView
 
+enum LoginTableViewCellType {
+    case none
+    case textField
+    case toggleSwitch
+}
+
 class LoginTableViewCell: TORoundedTableViewCapCell, UITextFieldDelegate {
+    
+    /* Explicitly set the type of this cell so the appropriate views can be configured */
+    public var type: LoginTableViewCellType = .textField {
+        didSet {
+            configureViews()
+        }
+    }
     
     // `lazy` wasn't flexible enough, so defer to old Objective-C style
     // lazy creation for now. (https://github.com/apple/swift-evolution/blob/master/proposals/0030-property-behavior-decls.md)
     private var _textField: UITextField? = nil
-    public var textField: UITextField {
-        setUpTextField()
-        return _textField!
+    public var textField: UITextField? {
+        return _textField
     }
     
     private var _switch: UISwitch? = nil
-    public var `switch`: UISwitch {
-        setUpSwitch()
-        return _switch!
+    public var `switch`: UISwitch? {
+        return _switch
     }
     
-    var textChangedHandler: (() -> Void)? {
-        didSet {
-            if textChangedHandler != nil { setUpTextField() }
-        }
-    }
-    
-    var returnButtonTappedHandler: (() -> Void)? {
-        didSet {
-            if returnButtonTappedHandler != nil { setUpTextField() }
-        }
-    }
-    
-    var switchChangedHandler: (() -> Void)? {
-        didSet {
-            if switchChangedHandler != nil { setUpSwitch() }
-        }
-    }
+    var textChangedHandler: (() -> Void)?
+    var returnButtonTappedHandler: (() -> Void)?
+    var switchChangedHandler: (() -> Void)?
     
     //MARK: - Class Creation
     
@@ -66,24 +63,26 @@ class LoginTableViewCell: TORoundedTableViewCapCell, UITextFieldDelegate {
     
     //MARK: - View Setup
     
-    func setUpTextField() {
-        guard _textField == nil else { return }
-    
-        _textField = UITextField()
-        _textField?.autocorrectionType = .no
-        _textField?.autocapitalizationType = .none
-        _textField?.delegate = self
-        _textField?.addTarget(self, action: #selector(textFieldDidChange(_:)), for: .editingChanged)
-        contentView.addSubview(_textField!)
-        setNeedsLayout()
-    }
-    
-    func setUpSwitch() {
-        guard _switch == nil else { return }
+    func configureViews() {
+        if type == .textField && _textField == nil {
+            _textField = UITextField()
+            _textField?.autocorrectionType = .no
+            _textField?.autocapitalizationType = .none
+            _textField?.delegate = self
+            _textField?.addTarget(self, action: #selector(textFieldDidChange(_:)), for: .editingChanged)
+            contentView.addSubview(_textField!)
+        }
         
-        _switch = UISwitch()
-        _switch?.addTarget(self, action: #selector(switchDidChange(_:)), for: .valueChanged)
-        contentView.addSubview(_switch!)
+        if type == .toggleSwitch && _switch == nil {
+            _switch = UISwitch()
+            _switch?.addTarget(self, action: #selector(switchDidChange(_:)), for: .valueChanged)
+            contentView.addSubview(_switch!)
+        }
+        
+        _textField?.isHidden = type != .textField
+        _switch?.isHidden = type != .toggleSwitch
+        
+        setNeedsLayout()
     }
 
     //MARK: - View Management


### PR DESCRIPTION
For certain apps (Like Realm Tasks) that have explicitly set server URLs, it's not necessary to expose the URL field.

This PR adds two properties `isServerURLFieldHidden` and `isRememberAccountDetailsFieldHidden` that will hide those particular fields as desired.

![simulator screen shot jan 25 2017 1 48 25 am](https://cloud.githubusercontent.com/assets/429119/22259589/e24fb73c-e2a0-11e6-937b-b817304e02b4.png)
