### PR TITLE
Improved layout on smaller screens

### DIFF
--- a/RealmLoginKit Apple/RealmLoginKit/Views/LoginHeaderView.swift
+++ b/RealmLoginKit Apple/RealmLoginKit/Views/LoginHeaderView.swift
@@ -73,10 +73,11 @@ class LoginHeaderView: UIView {
         realmLogoView.tintColor = .white
         realmLogoView.logoStrokeWidth = 3.0
         addSubview(realmLogoView)
-        
+
         titleLabel.font = UIFont.systemFont(ofSize: 28.0)
         titleLabel.textAlignment = .center
         titleLabel.textColor = .black
+        titleLabel.adjustsFontSizeToFitWidth = true
         addSubview(titleLabel)
         
         updateTitleView()
@@ -88,11 +89,11 @@ class LoginHeaderView: UIView {
         rect.size = CGSize(width: logoSize, height: logoSize)
         rect.origin.x = (bounds.size.width - CGFloat(logoSize)) * 0.5
         realmLogoView.frame = rect
-        
+
         titleLabel.sizeToFit()
         rect = titleLabel.frame
-        rect.origin.x = 0.0
-        rect.size.width = bounds.size.width
+        rect.origin.x = 15.0
+        rect.size.width = bounds.size.width - 30.0
         rect.origin.y = bounds.size.height - CGFloat(bottomMargin + Int(rect.size.height))
         titleLabel.frame = rect
     }


### PR DESCRIPTION
Fixes:

* The credits text at the bottom hides when the scroll content would have overlapped it.
* The scroll content now always accounts for the status bar offset.
* The log in title now changes size so it won't get truncated as easily.

![simulator screen shot feb 7 2017 5 38 57 pm](https://cloud.githubusercontent.com/assets/429119/22719836/507220c2-ed5c-11e6-8a6a-253c9f6591c7.png)