### PR TITLE
Add HTTPS support

### DIFF
--- a/RealmLoginKit Apple/RealmLoginKit.podspec
+++ b/RealmLoginKit Apple/RealmLoginKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'RealmLoginKit'
-  s.version  = '0.0.9'
+  s.version  = '0.0.10'
   s.license  =  { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.summary  = 'A generic login view controller for apps that use the Realm Mobile Platform'
   s.homepage = 'https://realm.io'

--- a/RealmLoginKit Apple/RealmLoginKit/Controllers/LoginViewController.swift
+++ b/RealmLoginKit Apple/RealmLoginKit/Controllers/LoginViewController.swift
@@ -274,6 +274,7 @@ public class LoginViewController: UIViewController, UITableViewDataSource, UITab
         // Only touch the text field if we're actively using it
         if tableViewCell.textChangedHandler != nil {
             tableViewCell.textField?.textColor = isDarkStyle ? .white : .black
+            tableViewCell.textField?.keyboardAppearance = isDarkStyle ? .dark : .default
 
             if isDarkStyle {
                 let placeholderText = tableViewCell.textField?.placeholder

--- a/RealmLoginKit Apple/RealmLoginKit/Controllers/LoginViewController.swift
+++ b/RealmLoginKit Apple/RealmLoginKit/Controllers/LoginViewController.swift
@@ -595,8 +595,10 @@ public class LoginViewController: UIViewController, UITableViewDataSource, UITab
         
         saveLoginCredentials()
         
+        var scheme: String?
         var formattedURL = serverURL
         if let schemeRange = formattedURL?.range(of: "://") {
+            scheme = formattedURL?.substring(to: schemeRange.lowerBound)
             formattedURL = formattedURL?.substring(from: schemeRange.upperBound)
         }
         
@@ -605,7 +607,8 @@ public class LoginViewController: UIViewController, UITableViewDataSource, UITab
         }
         
         let credentials = RLMSyncCredentials(username: email!, password: password!, register: isRegistering)
-        RLMSyncUser.__logIn(with: credentials, authServerURL: URL(string: "http://\(formattedURL!)")!, timeout: 30, onCompletion: { (user, error) in
+        let authScheme = scheme == "realms" ? "https" : "http"
+        RLMSyncUser.__logIn(with: credentials, authServerURL: URL(string: "\(authScheme)://\(formattedURL!)")!, timeout: 30, onCompletion: { (user, error) in
             DispatchQueue.main.async {
                 self.footerView.isSubmitting = false
                 

--- a/RealmLoginKit Apple/RealmLoginKit/Controllers/LoginViewController.swift
+++ b/RealmLoginKit Apple/RealmLoginKit/Controllers/LoginViewController.swift
@@ -602,10 +602,6 @@ public class LoginViewController: UIViewController, UITableViewDataSource, UITab
             formattedURL = formattedURL?.substring(from: schemeRange.upperBound)
         }
         
-        if formattedURL?.range(of: ":") == nil {
-            formattedURL = "\(formattedURL!):9080"
-        }
-        
         let credentials = RLMSyncCredentials(username: email!, password: password!, register: isRegistering)
         let authScheme = scheme == "realms" ? "https" : "http"
         RLMSyncUser.__logIn(with: credentials, authServerURL: URL(string: "\(authScheme)://\(formattedURL!)")!, timeout: 30, onCompletion: { (user, error) in

--- a/RealmLoginKit Apple/RealmLoginKit/Controllers/LoginViewController.swift
+++ b/RealmLoginKit Apple/RealmLoginKit/Controllers/LoginViewController.swift
@@ -124,6 +124,7 @@ public class LoginViewController: UIViewController, UITableViewDataSource, UITab
     
     /* Login/Register Credentials */
     public var serverURL: String?       { didSet { validateFormItems() } }
+    public var serverPort = 9080        { didSet { validateFormItems() } }
     public var email: String?           { didSet { validateFormItems() } }
     public var password: String?        { didSet { validateFormItems() } }
     public var confirmPassword: String? { didSet { validateFormItems() } }
@@ -388,6 +389,10 @@ public class LoginViewController: UIViewController, UITableViewDataSource, UITab
         if serverURL == nil || (serverURL?.isEmpty)! {
             formIsValid = false
         }
+        
+        if !(0...65535 ~= serverPort) {
+            formIsValid = false
+        }
 
         if email?.range(of: "@") == nil || email?.range(of: ".") == nil {
             formIsValid = false
@@ -596,16 +601,25 @@ public class LoginViewController: UIViewController, UITableViewDataSource, UITab
         
         saveLoginCredentials()
         
+        var authScheme = "http"
         var scheme: String?
         var formattedURL = serverURL
         if let schemeRange = formattedURL?.range(of: "://") {
             scheme = formattedURL?.substring(to: schemeRange.lowerBound)
+            if scheme == "realms" || scheme == "https" {
+                serverPort = 9443
+                authScheme = "https"
+            }
             formattedURL = formattedURL?.substring(from: schemeRange.upperBound)
+        }
+        if let portRange = formattedURL?.range(of: ":") {
+            if let portString = formattedURL?.substring(from: portRange.upperBound) {
+                serverPort = Int(portString) ?? serverPort
+            }
         }
         
         let credentials = RLMSyncCredentials(username: email!, password: password!, register: isRegistering)
-        let authScheme = scheme == "realms" ? "https" : "http"
-        RLMSyncUser.__logIn(with: credentials, authServerURL: URL(string: "\(authScheme)://\(formattedURL!)")!, timeout: 30, onCompletion: { (user, error) in
+        RLMSyncUser.__logIn(with: credentials, authServerURL: URL(string: "\(authScheme)://\(formattedURL!):\(serverPort)")!, timeout: 30, onCompletion: { (user, error) in
             DispatchQueue.main.async {
                 self.footerView.isSubmitting = false
                 


### PR DESCRIPTION
The first commit fixes an issue where https auth server URLs were not supported.
The second commit is probably worth a separate discussion. What should the expected default port be if none is specified? For auth server URLs, which relies on http:/https:, 80 and 443 are inferred. However, for realm:/realms: sync server URLs, it's possible that the user may expect 9080/9443.