### PR TITLE
Added Granular Copyright Label Control

### DIFF
--- a/RealmLoginKit Apple/Podfile
+++ b/RealmLoginKit Apple/Podfile
@@ -3,6 +3,7 @@ platform :ios, '9.0'
 
 def shared_pods
   pod 'RealmLoginKit', :path => 'RealmLoginKit.podspec'
+  pod 'Reveal-SDK', :configurations => ['Debug']
 end 
 
 target 'RealmLoginKitExample' do

--- a/RealmLoginKit Apple/Podfile
+++ b/RealmLoginKit Apple/Podfile
@@ -3,7 +3,7 @@ platform :ios, '9.0'
 
 def shared_pods
   pod 'RealmLoginKit', :path => 'RealmLoginKit.podspec'
-  pod 'Reveal-SDK', :configurations => ['Debug']
+  # pod 'Reveal-SDK', :configurations => ['Debug']
 end 
 
 target 'RealmLoginKitExample' do

--- a/RealmLoginKit Apple/Podfile.lock
+++ b/RealmLoginKit Apple/Podfile.lock
@@ -9,10 +9,12 @@ PODS:
   - RealmLoginKit/Core (0.0.15):
     - Realm
     - TORoundedTableView
+  - Reveal-SDK (8)
   - TORoundedTableView (0.0.3)
 
 DEPENDENCIES:
   - RealmLoginKit (from `RealmLoginKit.podspec`)
+  - Reveal-SDK
 
 EXTERNAL SOURCES:
   RealmLoginKit:
@@ -21,8 +23,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Realm: 07e5d3a9e0e41d65fd5f9f05150ed6295d0f093b
   RealmLoginKit: 4e6bc57eefc09304d6b4edfd1a520be79bf455b4
+  Reveal-SDK: 43be4e662864e937960d0d04d005135e29c4e53b
   TORoundedTableView: 4155565233135d81d6626a0c4ecfba27991cf2b1
 
-PODFILE CHECKSUM: 77878d4a6723c75e8828462867e128cf90e790a0
+PODFILE CHECKSUM: a7be17676669dd3bc40e5cbb8be16d85ce9c7849
 
 COCOAPODS: 1.2.1

--- a/RealmLoginKit Apple/RealmLoginKit.xcodeproj/project.pbxproj
+++ b/RealmLoginKit Apple/RealmLoginKit.xcodeproj/project.pbxproj
@@ -125,7 +125,6 @@
 			children = (
 				221840D81E2CCAE300E85B6E /* AppDelegate.swift */,
 				221840E71E2CCB5100E85B6E /* Controllers */,
-				221840E91E2CCB5100E85B6E /* Models */,
 				221840EA1E2CCB5100E85B6E /* Resources */,
 				221840EE1E2CCB5100E85B6E /* Support */,
 			);
@@ -140,14 +139,6 @@
 			);
 			name = Controllers;
 			path = RealmLoginKitExample/Controllers;
-			sourceTree = SOURCE_ROOT;
-		};
-		221840E91E2CCB5100E85B6E /* Models */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Models;
-			path = RealmLoginKitExample/Models;
 			sourceTree = SOURCE_ROOT;
 		};
 		221840EA1E2CCB5100E85B6E /* Resources */ = {

--- a/RealmLoginKit Apple/RealmLoginKit/Controllers/LoginViewController.swift
+++ b/RealmLoginKit Apple/RealmLoginKit/Controllers/LoginViewController.swift
@@ -97,6 +97,23 @@ public class LoginViewController: UIViewController {
     }
 
     /**
+     Sets whether the copyright label shown at the bottom of the
+     view is visible or not.
+     */
+    public var isCopyrightLabelHidden: Bool {
+        get { return self.loginView.isCopyrightLabelHidden }
+        set { self.loginView.isCopyrightLabelHidden = newValue }
+    }
+
+    /**
+     Sets the text shown in the copyright label.
+     */
+    public var copyrightLabelText: String {
+        get { return self.loginView.copyrightLabelText }
+        set { self.loginView.copyrightLabelText = newValue }
+    }
+
+    /**
      The port number that will be appended to the server URL when constructing the final
      authentication URL, if the server has been set as unsecure. Default value is 9080.
      Specifying a port in `serverURL` will override this value.

--- a/RealmLoginKit Apple/RealmLoginKit/Controllers/LoginViewController.swift
+++ b/RealmLoginKit Apple/RealmLoginKit/Controllers/LoginViewController.swift
@@ -173,7 +173,18 @@ public class LoginViewController: UIViewController {
         }
         get { return _isRegistering }
     }
-    
+
+    /**
+     Transitions the view controller between the 'logging in' and 'signing up'
+     states. Can be animated, or updated instantly.
+     */
+    public func setRegistering(_ isRegistering: Bool, animated: Bool) {
+        guard _isRegistering != isRegistering else { return }
+        _isRegistering = isRegistering
+        tableDataSource.setRegistering(isRegistering, animated: animated)
+        loginView.setRegistering(isRegistering, animated: animated)
+    }
+
     /**
      Upon successful login/registration, this callback block will be called,
      providing the user account object that was returned by the server.
@@ -334,18 +345,8 @@ public class LoginViewController: UIViewController {
         self.password = credentials.password
     }
 
-    func setRegistering(_ isRegistering: Bool, animated: Bool) {
-        guard _isRegistering != isRegistering else {
-            return
-        }
+    //MARK: - Form Submission -
 
-        _isRegistering = isRegistering
-
-        tableDataSource.setRegistering(isRegistering, animated: animated)
-        loginView.setRegistering(isRegistering, animated: animated)
-    }
-    
-    //MARK: - Form Submission
     private func prepareForSubmission() {
         // Validate the supplied credentials
         var isFormValid = true

--- a/RealmLoginKit Apple/RealmLoginKit/Views/LoginView.swift
+++ b/RealmLoginKit Apple/RealmLoginKit/Views/LoginView.swift
@@ -268,14 +268,14 @@ class LoginView: UIView, UITableViewDelegate, UIViewControllerTransitioningDeleg
     public override func layoutSubviews() {
         super.layoutSubviews()
 
-        // Hide the copyright view if there's not enough space on screen
-        updateCopyrightViewVisibility()
-
         // Recalculate the state for the on-screen views
         layoutTableContentInset()
         layoutNavigationBar()
         layoutCopyrightView()
         layoutCloseButton()
+
+        // Hide the copyright view if there's not enough space on screen
+        updateCopyrightViewVisibility()
     }
 
     public func animateContentInsetTransition() {
@@ -389,6 +389,7 @@ class LoginView: UIView, UITableViewDelegate, UIViewControllerTransitioningDeleg
         let verticalOffset = tableView.contentOffset.y
         let normalizedOffset = verticalOffset + tableView.contentInset.top
         copyrightView.frame.origin.y = (bounds.height - copyrightViewMargin) - normalizedOffset
+        copyrightView.frame.origin.x = floor((bounds.size.width - copyrightView.frame.size.width) * 0.5)
     }
 
     public func layoutCloseButton() {

--- a/RealmLoginKit Apple/RealmLoginKit/Views/LoginView.swift
+++ b/RealmLoginKit Apple/RealmLoginKit/Views/LoginView.swift
@@ -58,14 +58,40 @@ class LoginView: UIView, UITableViewDelegate, UIViewControllerTransitioningDeleg
         get { return _registering }
     }
 
+    /* Removes the Realm copyright text at the bottom. */
+    public var isCopyrightLabelHidden = false {
+        didSet {
+            if isCopyrightLabelHidden {
+                copyrightView?.removeFromSuperview()
+                copyrightView = nil
+            }
+            else {
+                setUpCopyrightLabel()
+                applyTheme()
+            }
+            self.setNeedsLayout()
+        }
+    }
+
+    /* The copyright text displayed at the bottom of 
+     the view when there is sufficient space */
+    public var copyrightLabelText = "With ❤️ from the Realm team, 2017." {
+        didSet {
+            setUpCopyrightLabel()
+            copyrightView?.text = copyrightLabelText
+            copyrightView?.sizeToFit()
+            self.setNeedsLayout()
+        }
+    }
+
     /* Subviews */
     public let containerView = UIView()
     public let navigationBar = UINavigationBar()
     public let tableView     = TORoundedTableView()
     public let headerView    = LoginHeaderView()
     public let footerView    = LoginFooterView()
-    public let copyrightView = UILabel()
-    public var closeButton: UIButton? = nil
+    public var copyrightView: UILabel?
+    public var closeButton: UIButton?
 
     public var effectView: UIVisualEffectView?
     public var backgroundView: UIView?
@@ -160,6 +186,23 @@ class LoginView: UIView, UITableViewDelegate, UIViewControllerTransitioningDeleg
         applyTheme()
     }
 
+    private func setUpCopyrightLabel()
+    {
+        guard isCopyrightLabelHidden == false, copyrightView == nil else { return }
+
+        copyrightView = UILabel()
+        guard let copyrightView = copyrightView else { return }
+
+        copyrightView.text = copyrightLabelText
+        copyrightView.textAlignment = .center
+        copyrightView.font = UIFont.systemFont(ofSize: 15)
+        copyrightView.sizeToFit()
+        copyrightView.autoresizingMask = [.flexibleLeftMargin, .flexibleRightMargin, .flexibleTopMargin]
+        copyrightView.frame.origin.y = self.bounds.height - copyrightViewMargin
+        copyrightView.frame.origin.x = (self.bounds.width - copyrightView.frame.width) * 0.5
+        containerView.addSubview(copyrightView)
+    }
+
     private func setUpCommonViews() {
         backgroundView = UIView()
         backgroundView?.frame = bounds
@@ -175,17 +218,9 @@ class LoginView: UIView, UITableViewDelegate, UIViewControllerTransitioningDeleg
         navigationBar.alpha = 0.0
         self.addSubview(navigationBar)
 
-        copyrightView.text = "With ❤️ from the Realm team, 2017."
-        copyrightView.textAlignment = .center
-        copyrightView.font = UIFont.systemFont(ofSize: 15)
-        copyrightView.sizeToFit()
-        copyrightView.autoresizingMask = [.flexibleLeftMargin, .flexibleRightMargin, .flexibleTopMargin]
-        copyrightView.frame.origin.y = self.bounds.height - copyrightViewMargin
-        copyrightView.frame.origin.x = (self.bounds.width - copyrightView.frame.width) * 0.5
-        containerView.addSubview(copyrightView)
-
         setUpTableView()
         setUpCloseButton()
+        setUpCopyrightLabel()
         
         applyTheme()
     }
@@ -193,7 +228,7 @@ class LoginView: UIView, UITableViewDelegate, UIViewControllerTransitioningDeleg
     private func applyTheme() {
         // view accessory views
         navigationBar.barStyle  = isDarkStyle ? .blackTranslucent : .default
-        copyrightView.textColor = isDarkStyle ? UIColor(white: 0.3, alpha: 1.0) : UIColor(white: 0.6, alpha: 1.0)
+        copyrightView?.textColor = isDarkStyle ? UIColor(white: 0.3, alpha: 1.0) : UIColor(white: 0.6, alpha: 1.0)
 
         // view background
         if isTranslucentStyle {
@@ -315,6 +350,8 @@ class LoginView: UIView, UITableViewDelegate, UIViewControllerTransitioningDeleg
     }
 
     public func updateCopyrightViewVisibility() {
+        guard let copyrightView = copyrightView else { return }
+
         // Hide the copyright if there's not enough vertical space on the screen for it to not
         // interfere with the rest of the content
         let isHidden = (tableView.contentInset.top + tableView.contentSize.height) > copyrightView.frame.minY
@@ -344,7 +381,7 @@ class LoginView: UIView, UITableViewDelegate, UIViewControllerTransitioningDeleg
     }
 
     public func layoutCopyrightView() {
-        guard copyrightView.isHidden == false else {
+        guard let copyrightView = copyrightView, copyrightView.isHidden == false else {
             return
         }
 


### PR DESCRIPTION
As part of making `RealmLoginKit` more usable to third party developers, two new APIs have been added:

`isCopyrightLabelHidden` - To outright hide the label at all times.
`copyrightLabelText` - To override "With ❤️ from Realm" with something else.