### PR TITLE
Documented enabling third party auth providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ In order to run the Realm LoginKit demo app, it is necessary to install CocoaPod
 #### CocoaPods
 CocoaPods is the recommended way to install Realm LoginKit into an app as this will automatically manage recycling Realm Objective-C as a dependency. In your `PodFile`, simply add `pod 'RealmLoginKit'`.
 
+Realm LoginKit also provides support for third party authentication providers. However, since these providers may require additional dependencies that might otherwise be redundant, they are being isolated in separated CocoaPods subspecs:  
+
+* **Amazon Cognito** - `pod 'RealmLoginKit/AWSCognito'`
+
 #### Manually
 You can also integrate Realm LoginKit manually; simply copy the `RealmLoginKit` folder to your app, and drag it into Xcode. That being said, you will also need to install the [dependencies](#third-party-dependencies) separately as well. See their respective GitHub repositories for installation instructions.
 

--- a/RealmLoginKit Apple/Podfile
+++ b/RealmLoginKit Apple/Podfile
@@ -2,8 +2,14 @@
 platform :ios, '9.0'
 
 def shared_pods
+  # This is the default version of RealmLoginKit. Comment this line out if you want to use
+  # a specific third-party login mechanism, such as AWS Cognito
   pod 'RealmLoginKit', :path => 'RealmLoginKit.podspec'
-  pod 'RealmLoginKit/AWSCognito', :path => 'RealmLoginKit.podspec'
+
+  # Uncomment this line if you want to enable the AWS Cognito features of RealmLoginKit
+  # pod 'RealmLoginKit/AWSCognito', :path => 'RealmLoginKit.podspec'
+
+  # Client-side component of http://revealapp.com used for UI debugging
   # pod 'Reveal-SDK', :configurations => ['Debug']
 end 
 

--- a/RealmLoginKit Apple/RealmLoginKitExample/Controllers/ViewController.swift
+++ b/RealmLoginKit Apple/RealmLoginKitExample/Controllers/ViewController.swift
@@ -54,6 +54,13 @@ class ViewController: UIViewController {
     @IBAction func showLoginButtonTapped(_ sender: AnyObject?) {
         let style: LoginViewControllerStyle = isDarkMode ? .darkTranslucent : .lightTranslucent
         let loginViewController = LoginViewController(style: style)
+
+        /**
+         To enable Amazon Cognito functionality in this sampe app, make sure to open the Podfile in the same directory
+         and make sure to swap out the commented out lines, making sure the `pod 'RealmLoginKit/AWSCognito` line is uncommented,
+         and then run another `pod install` command.
+         */
+
 //        loginViewController.authenticationProvider = AWSCognitoAuthenticationProvider(serviceRegion: .USEast1, userPoolID: "",
 //                                                                                      clientID: "",
 //                                                                                      clientSecret: "")


### PR DESCRIPTION
The sample app (And default CocoaPods podspec) only allow the standard Realm authentication methods by default. This is because other authentication methods will require importing additional dependencies (Possibly even large binary packages) and these will be redundant unless that provider is explicitly sought.

This PR adds additional comments and documentation indicating this is the case, and highlights what lines of code need to be modified in the sample app in order to enable them.